### PR TITLE
Add an example to show how to access a JVM property

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,17 @@
 #!/usr/bin/env nextflow
 
+
+// The setProperty command shows how we can access the key-value pair passed as a JVM system property via the -D option.
+
+/*
+$ nextflow -Dkey=value run main.nf
+value
+... executor >  local (3) ...
+*/
+
+println(System.setProperty("key", "RL"));
+
+
 cheers = Channel.from 'Bonjour', 'Ciao', 'Hello', 'Hola'
 
 process sayHello {


### PR DESCRIPTION
Hi team,

I plan to use this example to show the usage of `-D` option as it relates to this PR https://github.com/nextflow-io/nextflow/pull/1751

Could you please create a new branch `jvm-properties` and merge this PR there?


